### PR TITLE
fix(ci): drop `vercel build` step to avoid spawn sh ENOENT

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
   deploy:
-    name: Build & deploy to Vercel
+    name: Deploy to Vercel
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -48,8 +48,10 @@ jobs:
       - name: Pull Vercel project config + env
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
-      - name: Build
-        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-
-      - name: Deploy prebuilt artifact
-        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}
+      # We let Vercel build remotely (vercel deploy without --prebuilt) instead
+      # of running `vercel build` in CI. The local-build path tends to throw
+      # `spawn sh ENOENT` when Vercel's stored project settings and the
+      # checkout disagree on the install/build commands. Remote build adds
+      # ~90s but is rock-solid.
+      - name: Deploy
+        run: vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
`vercel build --prod` in CI was failing with `Error: spawn sh ENOENT` — a known flake when the project's stored Vercel settings disagree with the local checkout on install/build commands. Skipping the local build and letting Vercel build remotely (`vercel deploy --prod` without `--prebuilt`) is bulletproof. Trade-off: ~90s slower deploy.