### PR TITLE
fix(ci): run workflow from repo root, not frontend/

### DIFF
--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -24,9 +24,10 @@ jobs:
   deploy:
     name: Deploy to Vercel
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
+    # NOTE: do NOT set working-directory to frontend/ here. The Vercel
+    # project's Root Directory is already configured as `frontend`, and
+    # Vercel CLI joins cwd + that setting — running from frontend/ would
+    # produce `frontend/frontend` and the deploy fails. Run from repo root.
 
     steps:
       - name: Checkout
@@ -48,10 +49,8 @@ jobs:
       - name: Pull Vercel project config + env
         run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
-      # We let Vercel build remotely (vercel deploy without --prebuilt) instead
-      # of running `vercel build` in CI. The local-build path tends to throw
-      # `spawn sh ENOENT` when Vercel's stored project settings and the
-      # checkout disagree on the install/build commands. Remote build adds
-      # ~90s but is rock-solid.
+      # Vercel builds remotely (no `--prebuilt`) which avoids the
+      # `spawn sh ENOENT` flakes the local-build path is prone to. Adds
+      # ~90s to the deploy but is rock-solid.
       - name: Deploy
         run: vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
Vercel CLI joins the current working directory with the project's "Root Directory" setting. Our project has Root Directory = `frontend`, and the workflow had `working-directory: frontend`, so Vercel was looking for `frontend/frontend` — which doesn't exist.

Removing the `defaults.run.working-directory` lets the CLI resolve the project root from `vercel pull`'s config alone, which is correct.