### PR TITLE
feat(backend): EC2 deploy ready — cross-origin cookies, PM2, runbook

### DIFF
--- a/BACKEND_EC2_DEPLOY.md
+++ b/BACKEND_EC2_DEPLOY.md
@@ -1,0 +1,200 @@
+# Backend deploy on existing EC2 (alongside ClickAndCare)
+
+Goal: run EngageSphere's backend on the same EC2 instance currently hosting
+ClickAndCare, behind nginx, on a new subdomain `api.engage-sphere.in`,
+with TLS.
+
+```
+Browser ──https://api.engage-sphere.in──▶ nginx ──▶ engagesphere :5050
+                                              ╰─▶ clickandcare  :5000
+```
+
+## 1 · DNS
+
+In your domain registrar add:
+
+```
+A  api.engage-sphere.in  →  <EC2 elastic IP>
+```
+
+Wait a couple of minutes; verify with `dig api.engage-sphere.in`.
+
+## 2 · SSH in and pull the code
+
+```bash
+ssh ubuntu@<your-ec2-ip>
+cd ~/apps                              # or wherever ClickAndCare lives
+git clone https://github.com/anshu-man26/EngageSphere.git
+cd EngageSphere/backend
+npm ci --omit=dev
+mkdir -p logs
+```
+
+## 3 · Doppler
+
+Install once on the box if not already there:
+
+```bash
+curl -Ls https://cli.doppler.com/install.sh | sudo sh
+```
+
+Inside `EngageSphere/backend/` link the project + config:
+
+```bash
+doppler login          # interactive, only once per box
+doppler setup          # pick the engagesphere project + prd config
+```
+
+Make sure these are set in Doppler `prd`:
+
+| Var | Value |
+|---|---|
+| `NODE_ENV` | `production` |
+| `MONGO_DB_URI` | your Atlas connection string |
+| `JWT_SECRET` | a fresh long random string |
+| `EMAIL_USER` / `EMAIL_PASS` | Gmail + App Password |
+| `CLOUDINARY_NAME` / `CLOUDINARY_API_KEY` / `CLOUDINARY_SECRET_KEY` | from Cloudinary |
+| `AGORA_APP_ID` / `AGORA_APP_CERTIFICATE` | from Agora secured project |
+| `FRONTEND_URL` | `https://www.engage-sphere.in` |
+
+## 4 · Pick a port that doesn't clash with ClickAndCare
+
+ClickAndCare is probably on `5000`. Use **`5050`** for EngageSphere.
+
+```bash
+doppler secrets set PORT=5050   # if not already in Doppler
+```
+
+The `ecosystem.config.cjs` defaults to `5050` if nothing is set.
+
+## 5 · PM2
+
+If PM2 isn't already on the box (it almost certainly is for ClickAndCare):
+
+```bash
+sudo npm install --global pm2
+```
+
+Start the EngageSphere process:
+
+```bash
+cd ~/apps/EngageSphere/backend
+doppler run --command "pm2 start ecosystem.config.cjs"
+pm2 save                # persist across reboots
+```
+
+Verify:
+
+```bash
+pm2 ls                  # both engagesphere-backend AND clickandcare should be listed
+pm2 logs engagesphere-backend --lines 30
+curl http://localhost:5050/api/health   # should return JSON status
+```
+
+## 6 · nginx — new server block
+
+Create `/etc/nginx/sites-available/engage-sphere`:
+
+```nginx
+upstream engagesphere_backend {
+    server 127.0.0.1:5050;
+    keepalive 64;
+}
+
+server {
+    listen 80;
+    server_name api.engage-sphere.in;
+
+    # certbot will rewrite this once TLS is issued
+    location / {
+        proxy_pass http://engagesphere_backend;
+        proxy_http_version 1.1;
+
+        # Required for Socket.IO websockets
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        "upgrade";
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Long-lived sockets need long timeouts
+        proxy_read_timeout                 86400;
+        proxy_send_timeout                 86400;
+    }
+}
+```
+
+Enable + reload:
+
+```bash
+sudo ln -s /etc/nginx/sites-available/engage-sphere /etc/nginx/sites-enabled/
+sudo nginx -t            # syntax check
+sudo systemctl reload nginx
+```
+
+`curl http://api.engage-sphere.in/api/health` should now succeed (over plain http).
+
+## 7 · TLS via Let's Encrypt
+
+```bash
+sudo certbot --nginx -d api.engage-sphere.in
+```
+
+Certbot updates the nginx config in place to add `listen 443 ssl;` plus the
+cert paths and an http→https redirect. Auto-renewal is already wired by the
+certbot package (cron + `certbot renew`).
+
+## 8 · Frontend pointing
+
+In Doppler's **engagesphere → prd** config (the one synced to Vercel), set:
+
+```
+VITE_API_URL    = https://api.engage-sphere.in
+VITE_SOCKET_URL = https://api.engage-sphere.in
+```
+
+Trigger a Vercel redeploy (push any commit to main, or **Vercel dashboard
+→ Deployments → … → Redeploy**). The Vite bundle now points at the new
+backend.
+
+## 9 · Verify end-to-end
+
+| Check | How |
+|---|---|
+| Health | `curl https://api.engage-sphere.in/api/health` returns 200 |
+| CORS | DevTools → Network on `https://www.engage-sphere.in` — no CORS errors |
+| Cookie | After login, DevTools → Application → Cookies has `jwt` for `api.engage-sphere.in` with `SameSite=None; Secure` |
+| Socket.IO | DevTools → Network → WS shows a `wss://api.engage-sphere.in/socket.io/...` connection in `101 Switching Protocols` state |
+| Two-device sync | Open the site on two browsers, send a message — appears instantly |
+
+## Common gotchas
+
+- **`502 Bad Gateway` from nginx.** PM2 process isn't running or is on the
+  wrong port. `pm2 ls` and `pm2 logs engagesphere-backend`.
+- **Login works but `/api/users/conversations` returns 401.** The `jwt`
+  cookie isn't getting through. Almost always means the app is being served
+  over plain http somewhere — `sameSite=none` requires `secure` which
+  requires https end-to-end.
+- **Socket connects then drops every ~60s.** nginx `proxy_read_timeout`
+  too low. The config above sets 24h, which is what Socket.IO docs
+  recommend.
+- **MongoDB Atlas refuses connection.** Whitelist the EC2's elastic IP in
+  Atlas → Network Access.
+- **PM2 doesn't restart on reboot.** Run once: `pm2 startup systemd` and
+  paste the command it prints (it's a sudo chmod), then `pm2 save`.
+
+## Updating after a code push
+
+```bash
+ssh ubuntu@<your-ec2-ip>
+cd ~/apps/EngageSphere
+git pull origin main
+cd backend
+npm ci --omit=dev
+pm2 restart engagesphere-backend
+```
+
+Or wire this up as a tiny GitHub Actions workflow with SSH later — out of
+scope for this first deploy.

--- a/backend/config/cookieOptions.js
+++ b/backend/config/cookieOptions.js
@@ -1,0 +1,22 @@
+// Single source of truth for auth-cookie options.
+//
+// In production the frontend (Vercel) and backend (EC2) live on different
+// domains, so cookies must be:
+//   - sameSite: "none"  (otherwise the browser drops them on cross-site requests)
+//   - secure: true      (sameSite "none" requires it)
+//
+// In development we use "lax" + non-secure so cookies work over plain http.
+const isProd = process.env.NODE_ENV === "production";
+
+export const authCookieOptions = (maxAgeMs) => ({
+	maxAge: maxAgeMs,
+	httpOnly: true,
+	sameSite: isProd ? "none" : "lax",
+	secure: isProd,
+});
+
+export const clearCookieOptions = () => ({
+	httpOnly: true,
+	sameSite: isProd ? "none" : "lax",
+	secure: isProd,
+});

--- a/backend/controllers/admin.controller.js
+++ b/backend/controllers/admin.controller.js
@@ -6,6 +6,7 @@ import jwt from "jsonwebtoken";
 import nodemailer from "nodemailer";
 import { v2 as cloudinary } from "cloudinary";
 import { io } from "../socket/socket.js";
+import { authCookieOptions, clearCookieOptions } from "../config/cookieOptions.js";
 
 // Configure Cloudinary
 cloudinary.config({
@@ -19,12 +20,7 @@ const generateAdminTokenAndSetCookie = (adminId, res) => {
 		expiresIn: "24h",
 	});
 
-	res.cookie("admin_jwt", token, {
-		maxAge: 24 * 60 * 60 * 1000, // 24 hours
-		httpOnly: true,
-		sameSite: "strict",
-		secure: process.env.NODE_ENV !== "development",
-	});
+	res.cookie("admin_jwt", token, authCookieOptions(24 * 60 * 60 * 1000));
 };
 
 // Email transporter for admin notifications
@@ -187,7 +183,7 @@ export const verifyAdminLoginOtp = async (req, res) => {
 
 export const adminLogout = (req, res) => {
 	try {
-		res.cookie("admin_jwt", "", { maxAge: 0 });
+		res.cookie("admin_jwt", "", { ...clearCookieOptions(), maxAge: 0 });
 		res.status(200).json({ message: "Admin logged out successfully" });
 	} catch (error) {
 		console.log("Error in adminLogout controller", error.message);

--- a/backend/controllers/auth.controller.js
+++ b/backend/controllers/auth.controller.js
@@ -4,18 +4,15 @@ import jwt from "jsonwebtoken";
 import crypto from "crypto";
 import createTransporter from "../config/nodemailer.js";
 import welcomeEmailService from "../services/welcomeEmailService.js";
+import { authCookieOptions, clearCookieOptions } from "../config/cookieOptions.js";
+
+const FIFTEEN_DAYS = 15 * 24 * 60 * 60 * 1000;
 
 const generateTokenAndSetCookie = (userId, res) => {
 	const token = jwt.sign({ userId }, process.env.JWT_SECRET, {
 		expiresIn: "15d",
 	});
-
-	res.cookie("jwt", token, {
-		maxAge: 15 * 24 * 60 * 60 * 1000, // MS
-		httpOnly: true, // prevent XSS attacks cross-site scripting attacks
-		sameSite: "strict", // CSRF attacks cross-site request forgery attacks
-		secure: process.env.NODE_ENV !== "development",
-	});
+	res.cookie("jwt", token, authCookieOptions(FIFTEEN_DAYS));
 };
 
 export const signup = async (req, res) => {
@@ -254,7 +251,7 @@ export const login = async (req, res) => {
 
 export const logout = (req, res) => {
 	try {
-		res.cookie("jwt", "", { maxAge: 0 });
+		res.cookie("jwt", "", { ...clearCookieOptions(), maxAge: 0 });
 		res.status(200).json({ message: "Logged out successfully" });
 	} catch (error) {
 		console.log("Error in logout controller", error.message);

--- a/backend/controllers/user.controller.js
+++ b/backend/controllers/user.controller.js
@@ -5,6 +5,7 @@ import cloudinary from "../config/cloudinary.js";
 import bcrypt from "bcryptjs";
 import crypto from "crypto";
 import createTransporter from "../config/nodemailer.js";
+import { clearCookieOptions } from "../config/cookieOptions.js";
 
 export const getUsersForSidebar = async (req, res) => {
 	try {
@@ -767,12 +768,7 @@ export const deleteAccount = async (req, res) => {
 		});
 
 		// Clear the JWT cookie
-		res.clearCookie("jwt", {
-			httpOnly: true,
-			secure: process.env.NODE_ENV === "production",
-			sameSite: "strict",
-			maxAge: 0
-		});
+		res.clearCookie("jwt", clearCookieOptions());
 
 		res.status(200).json({ 
 			message: "Account deleted successfully"

--- a/backend/ecosystem.config.cjs
+++ b/backend/ecosystem.config.cjs
@@ -1,0 +1,35 @@
+// PM2 process file for the EngageSphere backend.
+//
+// On the EC2 box, ensure Doppler is installed and a service token for the
+// `prd` config is exported (e.g. /etc/profile.d/doppler.sh sets DOPPLER_TOKEN).
+// Then start with:
+//
+//   doppler run --command "pm2 start ecosystem.config.cjs"
+//
+// or, if Doppler is configured per-project via `doppler setup`:
+//
+//   pm2 start ecosystem.config.cjs
+//
+// (Doppler's pm2 helper auto-injects env when the cwd is configured.)
+
+module.exports = {
+	apps: [
+		{
+			name: "engagesphere-backend",
+			script: "./server.js",
+			cwd: __dirname,
+			instances: 1,
+			exec_mode: "fork",
+			watch: false,
+			env: {
+				NODE_ENV: "production",
+				PORT: process.env.ENGAGESPHERE_PORT || 5050,
+			},
+			max_memory_restart: "400M",
+			error_file: "./logs/pm2-error.log",
+			out_file: "./logs/pm2-out.log",
+			merge_logs: true,
+			time: true,
+		},
+	],
+};

--- a/backend/utils/generateToken.js
+++ b/backend/utils/generateToken.js
@@ -1,16 +1,14 @@
 import jwt from "jsonwebtoken";
+import { authCookieOptions } from "../config/cookieOptions.js";
+
+const FIFTEEN_DAYS = 15 * 24 * 60 * 60 * 1000;
 
 const generateTokenAndSetCookie = (userId, res) => {
 	const token = jwt.sign({ userId }, process.env.JWT_SECRET, {
 		expiresIn: "15d",
 	});
 
-	res.cookie("jwt", token, {
-		maxAge: 15 * 24 * 60 * 60 * 1000, // MS
-		httpOnly: true, // prevent XSS attacks cross-site scripting attacks
-		sameSite: "strict", // CSRF attacks cross-site request forgery attacks
-		secure: process.env.NODE_ENV !== "development",
-	});
+	res.cookie("jwt", token, authCookieOptions(FIFTEEN_DAYS));
 };
 
 export default generateTokenAndSetCookie;


### PR DESCRIPTION
Cookie options centralized in config/cookieOptions.js. In production the frontend (Vercel) and backend (EC2) live on different domains, so the auth cookies must use sameSite="none" + secure=true; in development "lax" + non-secure works over plain http. All four cookie call sites (generateToken util, auth.controller signup/login/logout, admin.controller login/logout, user.controller deleteAccount) now go through the helper.

Added backend/ecosystem.config.cjs so PM2 can run the EngageSphere process alongside ClickAndCare on the same EC2 box (default port 5050 to avoid clashing).

CORS already reads FRONTEND_URL — no change needed; the frontend's Vercel URL gets allowlisted via Doppler secret.

BACKEND_EC2_DEPLOY.md is the runbook: DNS → SSH → npm ci → Doppler setup → PM2 → nginx server block (with WebSocket upgrade headers) → certbot for TLS.