### PR TITLE
feat(backend): split for Lambda REST + EC2 socket deploy (mirrors Cli…

### DIFF
--- a/.github/workflows/release-backend.yml
+++ b/.github/workflows/release-backend.yml
@@ -1,0 +1,65 @@
+name: Build & Release — backend (AWS Lambda)
+
+# Manual-only. Trigger from the Actions tab when you want a new backend
+# build to hit Lambda.
+#
+# Env vars (MONGO_DB_URI, JWT_SECRET, CLOUDINARY_*, EMAIL_*, AGORA_*,
+# FRONTEND_URL) come from Doppler at deploy time via `doppler run`. Only
+# AWS credentials and the Doppler service token live in GitHub secrets.
+on:
+  workflow_dispatch:
+    inputs:
+      stage:
+        description: 'Serverless stage to deploy to'
+        required: true
+        default: 'production'
+        type: choice
+        options:
+          - production
+          - staging
+      confirm:
+        description: 'Type "release" to confirm'
+        required: true
+        default: ''
+
+concurrency:
+  group: release-backend-${{ inputs.stage }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    # Safety rail: user has to type "release" in the input to proceed.
+    if: ${{ inputs.confirm == 'release' }}
+    defaults:
+      run:
+        working-directory: backend
+    env:
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      AWS_REGION: ${{ secrets.AWS_REGION || 'ap-south-1' }}
+      DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN_BACKEND }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install production deps
+        run: npm ci --omit=dev
+
+      - name: Install Serverless Framework
+        run: npm i -g serverless@3
+
+      - name: Install Doppler CLI
+        uses: dopplerhq/cli-action@v3
+
+      - name: Build & Release (stage=${{ inputs.stage }})
+        # `doppler run --preserve-env` keeps AWS_* from the GH env intact
+        # while injecting MONGO_DB_URI / JWT_SECRET / CLOUDINARY_* / EMAIL_* /
+        # AGORA_* / FRONTEND_URL from Doppler. Serverless reads them via
+        # ${env:VAR} in serverless.yml and bakes them into the Lambda.
+        run: doppler run --preserve-env -- serverless deploy --stage ${{ inputs.stage }} --verbose

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,171 +1,178 @@
 # Deploying EngageSphere
 
-Frontend on **Vercel** via **GitHub Actions**, env vars managed by **Doppler**.
-Backend hosting decided separately (see end of file).
+Same shape as ClickAndCare:
 
-```
-GitHub push  ──▶  GitHub Actions  ──▶  vercel build  ──▶  Vercel CDN
-                                          ▲
-                                          │ (env vars synced)
-                                       Doppler
-```
+| Target | Where | Workflow |
+|---|---|---|
+| `frontend/` | Vercel | `.github/workflows/deploy-frontend.yml` (auto on push to main) |
+| `backend/` REST API | AWS Lambda + API Gateway | `.github/workflows/release-backend.yml` (manual) |
+| `backend/` Socket.IO | Shared EC2 with ClickAndCare | not in CI — pulled by hand |
 
----
+## Why the split
 
-## 1 · Doppler — set up the project
+Lambda can't hold persistent WebSocket connections. The Express app runs
+on Lambda for cheap, scalable REST. Socket.IO needs an always-on host —
+EngageSphere reuses the existing ClickAndCare EC2 (different port, different
+subdomain, same box).
 
-1. **Create a project** in Doppler (e.g. `engagesphere`) with two configs:
-   `dev` and `prd`.
-2. Add the frontend env vars to **prd**:
-   - `VITE_API_URL` — `https://api.yourdomain.com` (your backend origin)
-   - `VITE_SOCKET_URL` — same as above
-   - `VITE_AGORA_APP_ID` — fallback Agora App ID (optional)
-   - `VITE_GIPHY_API_KEY` — optional
-3. (Recommended) Install Doppler CLI locally and `doppler login` so you can
-   `doppler run -- npm run dev` in `frontend/` for local dev.
+## Env vars: Doppler is the source of truth
 
----
+Two configs in Doppler:
 
-## 2 · Vercel — connect the project
-
-1. **vercel.com → Add New → Project → Import** your GitHub repo.
-2. Vercel will detect the `frontend/vercel.json`. Confirm:
-   - **Root Directory:** `frontend`
-   - **Framework:** Vite (auto-detected)
-   - **Build Command:** `npm run build`
-   - **Output Directory:** `dist`
-3. **Disable** "Auto Deploy" on every push — we'll drive it from GitHub
-   Actions instead. (Settings → Git → toggle off.)
-4. (If you want Vercel to keep auto-deploying on push, leave it on and skip
-   step 4 below; the GitHub Actions workflow becomes optional.)
-
-### Wire Doppler → Vercel
-
-Use the official Doppler integration:
-
-1. Doppler dashboard → your project → **Integrations → Vercel** → connect.
-2. Pick the Vercel project + the `prd` config.
-3. Doppler now syncs every secret to Vercel's **Environment Variables → Production**
-   automatically — no manual copying.
-
----
-
-## 3 · GitHub Actions — the workflow
-
-The workflow lives at `.github/workflows/deploy-frontend.yml` and runs on:
-- any push to `main` that touches `frontend/**`
-- manual `workflow_dispatch`
-
-### Required GitHub repo secrets
-
-Set these in **Settings → Secrets and variables → Actions → New repository secret**:
-
-| Secret | Where to find it |
+| Doppler project / config | Used by |
 |---|---|
-| `VERCEL_TOKEN` | vercel.com → Account Settings → Tokens → Create |
-| `VERCEL_ORG_ID` | Run `vercel link` once locally — `.vercel/project.json` |
-| `VERCEL_PROJECT_ID` | Same file |
+| `engagesphere-fe / prd` | Vercel (synced via Doppler→Vercel integration) |
+| `engagesphere-be / prd` | Lambda + EC2 (read by `doppler run` at deploy/start time) |
 
-The fastest way to get the last two:
+Required vars in `engagesphere-be / prd`:
+
+- `NODE_ENV` = `production`
+- `MONGO_DB_URI`
+- `JWT_SECRET`
+- `EMAIL_USER`, `EMAIL_PASS`
+- `CLOUDINARY_NAME`, `CLOUDINARY_API_KEY`, `CLOUDINARY_SECRET_KEY`
+- `AGORA_APP_ID`, `AGORA_APP_CERTIFICATE`
+- `FRONTEND_URL` = `https://www.engage-sphere.in`
+- `OPENAI_API_KEY`, `API_KEY`, `ADMIN_EMAILS` (optional)
+
+Required vars in `engagesphere-fe / prd`:
+
+- `VITE_API_URL` = your Lambda HTTP API base (e.g.
+  `https://abc123.execute-api.ap-south-1.amazonaws.com`)
+- `VITE_SOCKET_URL` = `https://socket.engage-sphere.in` (your shared EC2
+  subdomain)
+- `VITE_AGORA_APP_ID` (optional fallback)
+- `VITE_GIPHY_API_KEY` (optional)
+
+## Backend — REST API (Lambda)
+
+### One-time AWS prep
+
+1. **IAM user** with programmatic access — `AdministratorAccess` or scoped
+   Serverless Framework permissions.
+2. **GitHub repo secrets** (Settings → Secrets and variables → Actions):
+
+| Secret | Value |
+|---|---|
+| `AWS_ACCESS_KEY_ID` | from IAM user |
+| `AWS_SECRET_ACCESS_KEY` | from IAM user |
+| `AWS_REGION` | optional, defaults to `ap-south-1` |
+| `DOPPLER_TOKEN_BACKEND` | Doppler service token scoped to `engagesphere-be / prd` (read-only) |
+
+### Running a release
+
+GitHub → **Actions** → **Build & Release — backend (AWS Lambda)** → **Run workflow**
+
+- `stage`: `production` or `staging`
+- `confirm`: type `release`
+
+The workflow runs:
+1. `npm ci --omit=dev` in `backend/`
+2. `npm i -g serverless@3`
+3. install Doppler CLI
+4. `doppler run --preserve-env -- serverless deploy --stage <stage>`
+
+After the first successful deploy, copy the API endpoint URL Serverless
+prints (looks like `https://abc123.execute-api.ap-south-1.amazonaws.com`)
+and put it in `engagesphere-fe / prd` → `VITE_API_URL`. Then redeploy the
+frontend (push any commit to main, or trigger the workflow manually).
+
+## Backend — Socket.IO (shared EC2)
+
+### Adding EngageSphere to the existing ClickAndCare EC2
 
 ```bash
-cd frontend
-npx vercel link            # follow prompts, picks the existing project
-cat .vercel/project.json   # copy "orgId" and "projectId"
+ssh ec2-user@<ec2 ip>
+cd ~/apps   # or wherever ClickAndCare lives
+git clone https://github.com/anshu-man26/EngageSphere.git
+cd EngageSphere/backend
+npm ci --omit=dev
+mkdir -p logs
 ```
 
-> Don't commit `.vercel/`. It's safe to leave there locally; it's gitignored
-> by default.
+Doppler is already installed (used by ClickAndCare). Link this folder:
 
-### What the workflow does
-
-1. Checks out the repo.
-2. Installs Node 20 + Vercel CLI.
-3. `vercel pull` — downloads project config + Doppler-synced env vars.
-4. `vercel build --prod` — runs the Vite build with prod env.
-5. `vercel deploy --prebuilt --prod` — uploads the prebuilt artifact (no
-   rebuilding on Vercel's side, deploy is ~10s instead of ~2min).
-
-That's it — push to main, watch the Actions tab, the new build goes live.
-
----
-
-## 4 · Custom domain on Vercel
-
-1. Vercel project → **Settings → Domains → Add** `yourdomain.com` (or
-   subdomain).
-2. Vercel shows the DNS records you need:
-   - **Apex** (`yourdomain.com`): `A 76.76.21.21`
-   - **Subdomain** (`app.yourdomain.com`): `CNAME cname.vercel-dns.com`
-3. Add those records at your domain registrar's DNS panel.
-4. Wait 5–30 minutes for DNS to propagate. TLS is auto-issued by Vercel.
-
----
-
-## 5 · Backend (still TODO)
-
-The frontend will call `VITE_API_URL` for REST and `VITE_SOCKET_URL` for
-Socket.IO. The backend needs to live somewhere — pick one:
-
-- **Railway** — easiest, supports Node + websockets, ~$5/month after trial.
-- **Render** — free tier sleeps; paid is fine.
-- **Fly.io** — Docker-based, generous free tier, the existing `Dockerfile` works.
-- **VPS** (DigitalOcean / Hetzner) — `docker compose up` + Caddy in front.
-
-When the backend is up, **two things must change** because frontend and backend
-are now on different origins:
-
-### a) Cookies must be cross-origin
-
-In `backend/utils/generateToken.js` and `backend/controllers/auth.controller.js`
-the cookie currently uses:
-
-```js
-sameSite: "strict",
-secure: process.env.NODE_ENV !== "development",
+```bash
+doppler setup    # pick engagesphere-be / prd
 ```
 
-For cross-origin auth (Vercel domain ↔ backend domain) change to:
+EngageSphere defaults to port `5050` (vs ClickAndCare's `3000`). Verify or
+set:
 
-```js
-sameSite: process.env.NODE_ENV === "production" ? "none" : "lax",
-secure: process.env.NODE_ENV === "production",
+```bash
+doppler secrets set PORT=5050
 ```
 
-`sameSite: "none"` requires `secure: true`, so make sure both origins are
-HTTPS in prod (they will be — Vercel issues TLS, your backend host should
-too).
+Start with PM2:
 
-### b) CORS must allow the Vercel origin
+```bash
+doppler run --command "pm2 start ecosystem.config.cjs"
+pm2 save
+```
 
-Set `FRONTEND_URL=https://app.yourdomain.com` in the backend's env (Doppler
-config for backend, separate from frontend). The existing CORS code in
-`backend/server.js` already reads `process.env.FRONTEND_URL` and adds it to
-the allowed origins list, so no code change needed.
+PM2 startup is already configured for the box (ClickAndCare set it up);
+the new process is captured by `pm2 save`'s snapshot.
 
----
+### Caddy / nginx for `socket.engage-sphere.in`
 
-## 6 · Post-deploy checklist
+Pick whichever the box already runs. Caddy example — append to
+`/etc/caddy/Caddyfile`:
 
-- [ ] Vercel build succeeds (Actions tab green)
-- [ ] `https://app.yourdomain.com` loads the React app
-- [ ] DevTools → Network: API calls go to `VITE_API_URL`, not `localhost:5000`
-- [ ] DevTools → Application → Cookies: `jwt` cookie is set after login
-- [ ] DevTools → Network → WS: Socket.IO upgrades to `wss://`
-- [ ] Sending a message in two devices syncs in real time
+```caddyfile
+socket.engage-sphere.in {
+    reverse_proxy localhost:5050 {
+        header_up Host {host}
+        header_up X-Real-IP {remote_host}
+        header_up X-Forwarded-For {remote_host}
+        header_up X-Forwarded-Proto https
+    }
+}
+```
 
----
+Then:
 
-## Common gotchas
+```bash
+sudo systemctl reload caddy
+```
 
-- **`vercel pull` says "no project linked"** in CI. → wrong `VERCEL_ORG_ID`
-  / `VERCEL_PROJECT_ID` secret.
-- **API calls hit `localhost:5000` in production.** → `VITE_API_URL` wasn't
-  set in Doppler-prd, OR the GitHub Actions ran before Doppler was wired
-  up. Re-run the workflow after fixing Doppler.
-- **Login works once but next page reload says you're logged out.** →
-  cookie `sameSite` is still `"strict"` after splitting frontend/backend.
-  See section 5a.
-- **`Failed to fetch` on first request after deploy.** → backend's CORS
-  doesn't include the Vercel domain. Set `FRONTEND_URL` in the backend's
-  Doppler config and redeploy backend.
+Caddy auto-issues TLS in ~30s. Test:
+
+```bash
+curl https://socket.engage-sphere.in/api/health
+```
+
+DNS: add `A  socket.engage-sphere.in  →  <EC2 IP>` at your registrar before
+running the Caddy reload.
+
+### Updating after a code push
+
+```bash
+ssh ec2-user@<ec2 ip>
+cd ~/apps/EngageSphere && git pull
+cd backend && npm ci --omit=dev
+pm2 restart engagesphere-backend
+```
+
+## Frontend — Vercel
+
+Already auto-deploys on push to main via
+`.github/workflows/deploy-frontend.yml`. Doppler→Vercel integration syncs
+env vars, so just keep `engagesphere-fe / prd` up to date.
+
+## Caveats
+
+- **API Gateway payload limit:** 10 MB. Cloudinary uploads cap at 5 MB,
+  safe.
+- **Lambda timeout:** 29 s (API Gateway hard cap 30 s).
+- **Mongo timeouts:** `serverSelectionTimeoutMS: 5000`,
+  `bufferCommands: false` — requests fail fast (5 s) if Mongo is down
+  instead of hitting the 29 s Lambda cap.
+- **Real-time push from Lambda:** any controller that calls
+  `io.to(...).emit(...)` from a Lambda invocation hits the no-op stub in
+  `socket/socket.js` — the message is saved, but recipients don't get a
+  live push from that path. Real-time chat flows through the EC2 socket
+  server (the frontend opens its WebSocket directly there via
+  `VITE_SOCKET_URL`).
+- **CORS on the socket host:** the EC2 socket server's CORS allow-list
+  reads `FRONTEND_URL` from the env, so make sure that's set correctly
+  in the Doppler config used on EC2.

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,0 +1,77 @@
+// Express app — pure HTTP. No socket.io, no .listen(). Used by both the
+// EC2 entrypoint (server.js, which adds socket.io) and the Lambda
+// entrypoint (lambda.js, which wraps it with serverless-http).
+import express from "express";
+import cookieParser from "cookie-parser";
+import cors from "cors";
+import path from "path";
+
+import authRoutes from "./routes/auth.routes.js";
+import messageRoutes from "./routes/message.routes.js";
+import userRoutes from "./routes/user.routes.js";
+import notificationRoutes from "./routes/notification.routes.js";
+import adminRoutes from "./routes/admin.routes.js";
+import complaintRoutes from "./routes/complaint.routes.js";
+import agoraRoutes from "./routes/agora.routes.js";
+
+const __dirname = path.resolve();
+const isProd = process.env.NODE_ENV === "production";
+
+const app = express();
+
+// CORS — same allow-list for both Lambda and EC2 entrypoints.
+app.use(
+	cors({
+		origin: [
+			"http://localhost:3000",
+			"http://localhost:5173",
+			process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null,
+			process.env.FRONTEND_URL,
+		].filter(Boolean),
+		credentials: true,
+		methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+		allowedHeaders: ["Content-Type", "Authorization", "X-Requested-With"],
+	}),
+);
+
+app.use(express.json());
+app.use(cookieParser());
+
+// Optional request logger (off by default — set LOG_REQUESTS=true to enable)
+if (process.env.LOG_REQUESTS === "true") {
+	app.use((req, _res, next) => {
+		console.log(`${req.method} ${req.path}`);
+		next();
+	});
+}
+
+// API routes
+app.use("/api/auth", authRoutes);
+app.use("/api/messages", messageRoutes);
+app.use("/api/users", userRoutes);
+app.use("/api/notifications", notificationRoutes);
+app.use("/api/admin", adminRoutes);
+app.use("/api/complaints", complaintRoutes);
+app.use("/api/agora", agoraRoutes);
+
+// Health check
+app.get("/api/health", (_req, res) => {
+	res.status(200).json({
+		status: "OK",
+		timestamp: new Date().toISOString(),
+		uptime: process.uptime(),
+		environment: process.env.NODE_ENV || "development",
+	});
+});
+
+// In production on EC2 the same Express server can also serve the SPA build
+// (when frontend is co-hosted). On Lambda this branch is a no-op since the
+// dist files aren't packaged.
+if (isProd) {
+	app.use(express.static(path.join(__dirname, "../frontend/dist")));
+	app.get("*", (_req, res) => {
+		res.sendFile(path.join(__dirname, "../frontend/dist/index.html"));
+	});
+}
+
+export default app;

--- a/backend/lambda.js
+++ b/backend/lambda.js
@@ -1,0 +1,58 @@
+// AWS Lambda entrypoint. Wraps the Express app with serverless-http and
+// caches the Mongo connection across invocations so warm invocations skip
+// the connection handshake.
+//
+// Socket.IO is NOT run here — Lambda can't hold persistent connections.
+// The long-lived socket server runs on EC2 (server.js + ecosystem.config.cjs).
+// Any controller that calls `io.to(...).emit(...)` from a Lambda invocation
+// hits the no-op stub in socket/socket.js — message is saved, but the
+// real-time push goes through whatever channel the EC2 socket server
+// broadcasts on.
+
+import "dotenv/config";
+import serverless from "serverless-http";
+import mongoose from "mongoose";
+import { v2 as cloudinary } from "cloudinary";
+import app from "./app.js";
+
+// ── Cloudinary (sync, no network) ────────────────────────────────
+cloudinary.config({
+	cloud_name: process.env.CLOUDINARY_NAME,
+	api_key: process.env.CLOUDINARY_API_KEY,
+	api_secret: process.env.CLOUDINARY_SECRET_KEY,
+});
+
+// ── Mongo connection cache ────────────────────────────────────────
+// Lambda re-uses the Node runtime across warm invocations, so we keep a
+// singleton promise for the connection. `bufferCommands: false` makes
+// queries fail fast instead of queueing if Mongo is unreachable, which
+// avoids requests hanging until the 29s API Gateway timeout.
+let connectionPromise = null;
+const connectToMongo = async () => {
+	if (mongoose.connection.readyState === 1) return;
+	if (!connectionPromise) {
+		connectionPromise = mongoose
+			.connect(process.env.MONGO_DB_URI, {
+				serverSelectionTimeoutMS: 5000,
+				bufferCommands: false,
+			})
+			.catch((err) => {
+				connectionPromise = null;
+				throw err;
+			});
+	}
+	await connectionPromise;
+};
+
+// ── Handler ──────────────────────────────────────────────────────
+const wrapped = serverless(app, {
+	binary: ["multipart/form-data", "application/octet-stream", "image/*"],
+});
+
+export const main = async (event, context) => {
+	// Keep the Lambda container alive after we return so Mongo's connection
+	// pool survives between invocations.
+	context.callbackWaitsForEmptyEventLoop = false;
+	await connectToMongo();
+	return wrapped(event, context);
+};

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -23,6 +23,7 @@
         "multer": "^2.0.1",
         "node-forge": "^1.3.1",
         "nodemailer": "^7.0.4",
+        "serverless-http": "^4.0.0",
         "socket.io": "^4.7.2"
       },
       "devDependencies": {
@@ -1982,6 +1983,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serverless-http": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/serverless-http/-/serverless-http-4.0.0.tgz",
+      "integrity": "sha512-KKl9h1+VApX9y2vHsVMogf906UXBwO3FDYiWPzqS0mCjEEx4Sx91JrssbWA7RN43HBuxrtoh8MkocZPvjyGnLg==",
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/setprototypeof": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,6 +25,7 @@
     "multer": "^2.0.1",
     "node-forge": "^1.3.1",
     "nodemailer": "^7.0.4",
+    "serverless-http": "^4.0.0",
     "socket.io": "^4.7.2"
   },
   "devDependencies": {

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,105 +1,28 @@
+// EC2 entry point. Sets up the HTTP server with the Express app, attaches
+// Socket.IO, and starts listening. Used by PM2 (ecosystem.config.cjs).
+//
+// All Express middleware + routes live in app.js so the same app can be
+// wrapped by serverless-http for Lambda (lambda.js).
 import "dotenv/config";
-import path from "path";
-import express from "express";
-import cookieParser from "cookie-parser";
-import cors from "cors";
-
-// Verify environment variables are loaded
-console.log("🔍 Environment Variables Check:");
-console.log("EMAIL_USER:", process.env.EMAIL_USER ? "✅ Set" : "❌ Missing");
-console.log("EMAIL_PASS:", process.env.EMAIL_PASS ? "✅ Set" : "❌ Missing");
-console.log("");
-
-import authRoutes from "./routes/auth.routes.js";
-import messageRoutes from "./routes/message.routes.js";
-import userRoutes from "./routes/user.routes.js";
-import notificationRoutes from "./routes/notification.routes.js";
-import adminRoutes from "./routes/admin.routes.js";
-import complaintRoutes from "./routes/complaint.routes.js";
-import agoraRoutes from "./routes/agora.routes.js";
-
+import http from "http";
+import app from "./app.js";
 import connectToMongoDB from "./db/connectToMongoDB.js";
-import { app, server } from "./socket/socket.js";
+import { createSocketServer } from "./socket/socket.js";
 import notificationService from "./services/notificationService.js";
 
-const __dirname = path.resolve();
-// PORT should be assigned after calling dotenv.config() because we need to access the env variables. Didn't realize while recording the video. Sorry for the confusion.
 const PORT = process.env.PORT || 5000;
 
-// CORS configuration
-app.use(cors({
-	origin: [
-		"http://localhost:3000",
-		"http://localhost:5173",
-		"http://10.18.214.234:3000",
-		process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null,
-		process.env.FRONTEND_URL
-	].filter(Boolean), // Allow both common frontend ports and your IP
-	credentials: true, // Allow cookies and authentication headers
-	methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
-	allowedHeaders: ["Content-Type", "Authorization", "X-Requested-With"]
-}));
+const server = http.createServer(app);
+createSocketServer(server);
 
-app.use(express.json()); // to parse the incoming requests with JSON payloads (from req.body)
-app.use(cookieParser());
-
-app.use("/api/auth", authRoutes);
-app.use("/api/messages", messageRoutes);
-app.use("/api/users", userRoutes);
-app.use("/api/notifications", notificationRoutes);
-app.use("/api/admin", adminRoutes);
-app.use("/api/complaints", complaintRoutes);
-app.use("/api/agora", agoraRoutes);
-
-// Health check endpoint
-app.get('/api/health', (req, res) => {
-	res.status(200).json({ 
-		status: 'OK', 
-		timestamp: new Date().toISOString(),
-		uptime: process.uptime(),
-		environment: process.env.NODE_ENV || 'development',
-		version: '1.0.0'
-	});
-});
-
-console.log("✅ Routes registered:");
-console.log("  - /api/auth");
-console.log("  - /api/messages");
-console.log("  - /api/users");
-console.log("  - /api/notifications");
-console.log("  - /api/admin");
-console.log("  - /api/complaints");
-console.log("  - /api/agora");
-console.log("  - /api/health");
-
-// Request logger — noisy in prod, only enabled when LOG_REQUESTS=true
-if (process.env.LOG_REQUESTS === "true") {
-	app.use((req, res, next) => {
-		console.log(`${req.method} ${req.path}`);
-		next();
-	});
-}
-
-// Only serve static files and handle frontend routes in production
-if (process.env.NODE_ENV === 'production') {
-	// Serve static files from the frontend/dist directory
-	app.use(express.static(path.join(__dirname, "../frontend/dist")));
-
-	// Handle all other routes by serving the React app
-	app.get("*", (req, res) => {
-		res.sendFile(path.join(__dirname, "../frontend/dist/index.html"));
-	});
-}
-
-server.listen(PORT, '0.0.0.0', () => {
+server.listen(PORT, "0.0.0.0", () => {
 	connectToMongoDB();
-	console.log(`Server running on port ${PORT} (${process.env.NODE_ENV || 'development'})`);
+	console.log(`Server running on port ${PORT} (${process.env.NODE_ENV || "development"})`);
 
-	// Start notification cleanup job (runs every 6 hours)
-	setInterval(() => {
-		notificationService.cleanupOldNotifications();
-	}, 6 * 60 * 60 * 1000);
-
-	// Run initial cleanup
+	// Notification cleanup runs every 6 hours
+	setInterval(
+		() => notificationService.cleanupOldNotifications(),
+		6 * 60 * 60 * 1000,
+	);
 	notificationService.cleanupOldNotifications();
 });

--- a/backend/serverless.yml
+++ b/backend/serverless.yml
@@ -1,0 +1,95 @@
+service: engagesphere-api
+frameworkVersion: '3'
+
+provider:
+  name: aws
+  runtime: nodejs20.x
+  region: ${env:AWS_REGION, 'ap-south-1'}
+  stage: ${opt:stage, 'production'}
+  memorySize: 512
+  timeout: 29  # API Gateway hard cap is 30s
+  logRetentionInDays: 14
+  environment:
+    NODE_ENV: production
+    MONGO_DB_URI: ${env:MONGO_DB_URI}
+    JWT_SECRET: ${env:JWT_SECRET}
+    CLOUDINARY_NAME: ${env:CLOUDINARY_NAME}
+    CLOUDINARY_API_KEY: ${env:CLOUDINARY_API_KEY}
+    CLOUDINARY_SECRET_KEY: ${env:CLOUDINARY_SECRET_KEY}
+    EMAIL_USER: ${env:EMAIL_USER}
+    EMAIL_PASS: ${env:EMAIL_PASS}
+    AGORA_APP_ID: ${env:AGORA_APP_ID, ''}
+    AGORA_APP_CERTIFICATE: ${env:AGORA_APP_CERTIFICATE, ''}
+    OPENAI_API_KEY: ${env:OPENAI_API_KEY, ''}
+    API_KEY: ${env:API_KEY, ''}
+    ADMIN_EMAILS: ${env:ADMIN_EMAILS, ''}
+    FRONTEND_URL: ${env:FRONTEND_URL}
+  httpApi:
+    cors:
+      allowedOrigins:
+        - ${env:FRONTEND_URL}
+      allowedHeaders:
+        - Content-Type
+        - Authorization
+        - X-Requested-With
+      allowedMethods:
+        - GET
+        - POST
+        - PUT
+        - DELETE
+        - OPTIONS
+      allowCredentials: true
+
+functions:
+  api:
+    handler: lambda.main
+    events:
+      - httpApi: '*'
+
+# API Gateway HTTP API stage-level throttling. Sized for personal use:
+# 25 req/sec sustained with 50 req/sec bursts before 429.
+resources:
+  extensions:
+    HttpApiStage:
+      Properties:
+        DefaultRouteSettings:
+          ThrottlingBurstLimit: 50
+          ThrottlingRateLimit: 25
+
+package:
+  individually: false
+  excludeDevDependencies: true
+  patterns:
+    # Default-deny most things, then allow code + production node_modules.
+    - '!**'
+    - 'lambda.js'
+    - 'app.js'
+    - 'package.json'
+    - 'config/**'
+    - 'controllers/**'
+    - 'db/**'
+    - 'middleware/**'
+    - 'models/**'
+    - 'routes/**'
+    - 'services/**'
+    - 'socket/**'
+    - 'utils/**'
+    - 'node_modules/**'
+    # Strip junk that crept into node_modules
+    - '!node_modules/.cache/**'
+    - '!node_modules/**/test/**'
+    - '!node_modules/**/tests/**'
+    - '!node_modules/**/__tests__/**'
+    - '!node_modules/**/example/**'
+    - '!node_modules/**/examples/**'
+    - '!node_modules/**/docs/**'
+    - '!node_modules/**/*.md'
+    - '!node_modules/**/*.ts'
+    - '!node_modules/**/*.map'
+    - '!ecosystem.config.cjs'
+    - '!nodemon.json'
+    - '!server.js'
+    - '!scripts/**'
+    - '!uploads/**'
+    - '!.env'
+    - '!.env.*'

--- a/backend/socket/socket.js
+++ b/backend/socket/socket.js
@@ -1,9 +1,12 @@
 // Socket.IO server — presence + signaling.
 //
-// One source of truth: `onlineUsers` (Map<userId, socketId>).
-// "Online" = "has a connected websocket". No heartbeats, no activity tracking,
-// no inactivity timers. Socket.IO already maintains the connection (with its
-// own ping/pong), so we trust `connect`/`disconnect` events and that's it.
+// In the new architecture this file is a *factory*:
+//   - On EC2 (server.js) we call createSocketServer(httpServer) to attach
+//     a real Socket.IO server to the http server.
+//   - On Lambda (lambda.js) we never call it — Lambda can't hold persistent
+//     connections — so the exported `io` stays a no-op stub. Any controller
+//     that accidentally calls `io.to(...).emit(...)` from a Lambda invocation
+//     simply does nothing instead of throwing.
 //
 // Public API (preserved for callers in controllers/services):
 //   - getReceiverSocketId(userId) → socketId | undefined
@@ -12,35 +15,28 @@
 //   - getActiveOnlineUsers() → string[]
 //   - clearAllOnlineUsers() → void  (admin tool)
 //   - sendOfflineNotification(...) → forwards to notificationService when offline
-//   - app, io, server (Express + Socket.IO instances)
+//   - io  (real Server instance after createSocketServer runs; stub before)
+//   - createSocketServer(httpServer) → real Server
 
 import { Server } from "socket.io";
-import http from "http";
-import express from "express";
 import notificationService from "../services/notificationService.js";
-
-const app = express();
-const server = http.createServer(app);
-
-const io = new Server(server, {
-	cors: {
-		origin: [
-			"http://localhost:3000",
-			"http://localhost:5173",
-			process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null,
-			process.env.FRONTEND_URL,
-		].filter(Boolean),
-		methods: ["GET", "POST"],
-		credentials: true,
-	},
-});
 
 // userId → socketId. Latest connection wins (multi-tab: newest tab gets events).
 const onlineUsers = new Map();
 
-const broadcastOnline = () => {
-	io.emit("getOnlineUsers", Array.from(onlineUsers.keys()));
+// `io` is exposed as a mutable export — controllers do `import { io } from
+// "../socket/socket.js"` and call `io.to(...)`. Until createSocketServer runs
+// it's a stub with no-op chains so Lambda doesn't crash.
+const noopChain = { emit: () => {} };
+const ioStub = {
+	to: () => noopChain,
+	emit: () => {},
+	on: () => {},
+	off: () => {},
+	use: () => {},
+	removeAllListeners: () => {},
 };
+export let io = ioStub;
 
 // ──────────────────── Public helpers ────────────────────
 export const getReceiverSocketId = (userId) => onlineUsers.get(userId);
@@ -50,7 +46,9 @@ export const getActiveOnlineUsers = () => Array.from(onlineUsers.keys());
 
 export const clearAllOnlineUsers = () => {
 	onlineUsers.clear();
-	broadcastOnline();
+	if (io && typeof io.emit === "function") {
+		io.emit("getOnlineUsers", []);
+	}
 };
 
 export const sendOfflineNotification = async (
@@ -74,8 +72,6 @@ export const sendOfflineNotification = async (
 };
 
 // ──────────────────── Admin stats helper ────────────────────
-// Triggers a fresh stats snapshot to all admin clients. Lazy import to avoid
-// a circular dependency at module load.
 const broadcastAdminStats = async () => {
 	try {
 		const { getSystemStats } = await import("../controllers/admin.controller.js");
@@ -94,43 +90,64 @@ const broadcastAdminStats = async () => {
 	}
 };
 
-// ──────────────────── Connection lifecycle ────────────────────
-io.on("connection", (socket) => {
-	const userId = socket.handshake.query.userId;
-	if (!userId || userId === "undefined") {
-		socket.disconnect(true);
-		return;
-	}
-
-	onlineUsers.set(userId, socket.id);
-	broadcastOnline();
-	broadcastAdminStats();
-
-	// Video-call signaling — pure passthrough to recipient
-	socket.on("videoCallStarted", (data) => {
-		const target = onlineUsers.get(data?.recipientId);
-		if (target) io.to(target).emit("videoCallStarted", data);
-	});
-	socket.on("videoCallEnded", (data) => {
-		const target = onlineUsers.get(data?.recipientId);
-		if (target) io.to(target).emit("videoCallEnded", data);
+// ──────────────────── Factory ────────────────────
+// Called once from server.js on the EC2 box. Returns the real Server so the
+// caller can keep a reference if needed.
+export const createSocketServer = (httpServer) => {
+	const realIo = new Server(httpServer, {
+		cors: {
+			origin: [
+				"http://localhost:3000",
+				"http://localhost:5173",
+				process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : null,
+				process.env.FRONTEND_URL,
+			].filter(Boolean),
+			methods: ["GET", "POST"],
+			credentials: true,
+		},
 	});
 
-	// Admin requests
-	socket.on("requestAdminStats", broadcastAdminStats);
-	socket.on("requestOnlineUsers", () => {
-		socket.emit("getOnlineUsers", Array.from(onlineUsers.keys()));
-	});
+	io = realIo;
 
-	socket.on("disconnect", () => {
-		// Only clear if THIS socket is still the tracked one (a newer tab from
-		// the same user may have replaced it).
-		if (onlineUsers.get(userId) === socket.id) {
-			onlineUsers.delete(userId);
-			broadcastOnline();
-			broadcastAdminStats();
+	const broadcastOnline = () => {
+		realIo.emit("getOnlineUsers", Array.from(onlineUsers.keys()));
+	};
+
+	realIo.on("connection", (socket) => {
+		const userId = socket.handshake.query.userId;
+		if (!userId || userId === "undefined") {
+			socket.disconnect(true);
+			return;
 		}
-	});
-});
 
-export { app, io, server };
+		onlineUsers.set(userId, socket.id);
+		broadcastOnline();
+		broadcastAdminStats();
+
+		// Video-call signaling — pure passthrough to recipient
+		socket.on("videoCallStarted", (data) => {
+			const target = onlineUsers.get(data?.recipientId);
+			if (target) realIo.to(target).emit("videoCallStarted", data);
+		});
+		socket.on("videoCallEnded", (data) => {
+			const target = onlineUsers.get(data?.recipientId);
+			if (target) realIo.to(target).emit("videoCallEnded", data);
+		});
+
+		// Admin requests
+		socket.on("requestAdminStats", broadcastAdminStats);
+		socket.on("requestOnlineUsers", () => {
+			socket.emit("getOnlineUsers", Array.from(onlineUsers.keys()));
+		});
+
+		socket.on("disconnect", () => {
+			if (onlineUsers.get(userId) === socket.id) {
+				onlineUsers.delete(userId);
+				broadcastOnline();
+				broadcastAdminStats();
+			}
+		});
+	});
+
+	return realIo;
+};


### PR DESCRIPTION
…ckAndCare)

Architecture
- backend/app.js  — Express app + middleware + routes. No socket, no listen.
- backend/server.js  — EC2 entry: import app, http.createServer, attach socket.io via createSocketServer(server), listen.
- backend/lambda.js  — Lambda entry: serverless-http wrap of app, with Mongo connection cache (bufferCommands:false, 5s serverSelectionTimeout) to avoid hanging requests when Mongo is unreachable.
- backend/socket/socket.js  — refactored from "creates app + io + server" to "exports createSocketServer(httpServer) factory + helpers". The `io` export starts as a no-op stub; createSocketServer replaces it with a real Server. Lambda imports never crash even if a controller calls `io.to(...).emit(...)`.

Deploy infra
- backend/serverless.yml  — Serverless Framework v3 config: HTTP API, ap-south-1 default, 512MB / 29s timeout, throttling 25 req/s + 50 burst, binary types for image uploads. Reads env vars from process.env (Doppler injects them at deploy time).
- .github/workflows/release-backend.yml  — Manual workflow_dispatch (with "type 'release' to confirm" guard). Installs Doppler CLI, runs `doppler run --preserve-env -- serverless deploy --stage <stage>`. Only AWS_* and DOPPLER_TOKEN_BACKEND live in GH secrets; everything else comes from Doppler at deploy time.
- DEPLOYMENT.md  — Full guide for Lambda deploy + adding EngageSphere to the existing ClickAndCare EC2 (PM2 + Caddy, port 5050).

Deps
- serverless-http added to backend dependencies.