### PR TITLE
fix(lambda): use /tmp on Lambda for multer disk storage, swallow mkdi…

### DIFF
--- a/backend/middleware/upload.js
+++ b/backend/middleware/upload.js
@@ -1,66 +1,66 @@
-import multer from 'multer';
-import path from 'path';
-import fs from 'fs';
+import multer from "multer";
+import path from "path";
+import fs from "fs";
 
-// Create uploads directory if it doesn't exist
-const uploadsDir = './uploads';
-if (!fs.existsSync(uploadsDir)) {
-	fs.mkdirSync(uploadsDir, { recursive: true });
+// Lambda's filesystem is read-only except /tmp. EC2 can write to ./uploads.
+// Pick a writable directory based on environment so module init never crashes.
+const isLambda = !!process.env.AWS_LAMBDA_FUNCTION_NAME;
+const uploadsDir = isLambda ? "/tmp/uploads" : "./uploads";
+
+try {
+	if (!fs.existsSync(uploadsDir)) {
+		fs.mkdirSync(uploadsDir, { recursive: true });
+	}
+} catch (err) {
+	// Don't crash module load. Disk-storage routes will fail at request
+	// time if the dir really isn't writable, which is the right place to
+	// surface that error.
+	console.warn(`upload.js: could not ensure uploads dir at ${uploadsDir}:`, err.message);
 }
 
+// In-memory storage for general uploads (sent straight to Cloudinary).
 const storage = multer.memoryStorage();
 
-// Configure multer for disk storage (for profile pictures)
+// Disk storage for profile pictures (small, single-shot).
 const diskStorage = multer.diskStorage({
-	destination: function (req, file, cb) {
-		cb(null, uploadsDir);
+	destination: (_req, _file, cb) => cb(null, uploadsDir),
+	filename: (_req, file, cb) => {
+		const unique = Date.now() + "-" + Math.round(Math.random() * 1e9);
+		cb(null, file.fieldname + "-" + unique + path.extname(file.originalname));
 	},
-	filename: function (req, file, cb) {
-		const uniqueSuffix = Date.now() + '-' + Math.round(Math.random() * 1E9);
-		cb(null, file.fieldname + '-' + uniqueSuffix + path.extname(file.originalname));
-	}
 });
 
-// File filter to allow images and documents
-const fileFilter = (req, file, cb) => {
-	console.log("File filter checking:", file.originalname, file.mimetype);
-	
-	const allowedImageTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
-	const allowedDocTypes = ['application/pdf', 'application/msword', 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', 'text/plain'];
-	
+// File filter — images + documents
+const fileFilter = (_req, file, cb) => {
+	const allowedImageTypes = ["image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp"];
+	const allowedDocTypes = [
+		"application/pdf",
+		"application/msword",
+		"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+		"text/plain",
+	];
 	if (allowedImageTypes.includes(file.mimetype) || allowedDocTypes.includes(file.mimetype)) {
-		console.log("File accepted:", file.originalname);
 		cb(null, true);
 	} else {
-		console.log("File rejected:", file.originalname, "Mime type:", file.mimetype);
-		cb(new Error('Only image and document files are allowed!'), false);
+		cb(new Error("Only image and document files are allowed!"), false);
 	}
 };
 
-// Configure multer
 const upload = multer({
-	storage: storage,
-	fileFilter: fileFilter,
-	limits: {
-		fileSize: 10 * 1024 * 1024, // 10MB limit for documents
-	},
+	storage,
+	fileFilter,
+	limits: { fileSize: 10 * 1024 * 1024 }, // 10 MB
 });
 
-// Configure multer for profile picture uploads (disk storage)
 const profilePicUpload = multer({
 	storage: diskStorage,
-	fileFilter: (req, file, cb) => {
-		const allowedImageTypes = ['image/jpeg', 'image/jpg', 'image/png', 'image/gif', 'image/webp'];
-		if (allowedImageTypes.includes(file.mimetype)) {
-			cb(null, true);
-		} else {
-			cb(new Error('Only image files are allowed for profile pictures!'), false);
-		}
+	fileFilter: (_req, file, cb) => {
+		const allowedImageTypes = ["image/jpeg", "image/jpg", "image/png", "image/gif", "image/webp"];
+		if (allowedImageTypes.includes(file.mimetype)) cb(null, true);
+		else cb(new Error("Only image files are allowed for profile pictures!"), false);
 	},
-	limits: {
-		fileSize: 5 * 1024 * 1024, // 5MB limit for profile pictures
-	},
-}).single('profilePic');
+	limits: { fileSize: 5 * 1024 * 1024 }, // 5 MB
+}).single("profilePic");
 
 export default upload;
-export { profilePicUpload }; 
+export { profilePicUpload };


### PR DESCRIPTION
…r failure

Lambda's filesystem is read-only except /tmp, so the module-init mkdirSync('./uploads') was crashing the function before it could ever serve a request. Detect Lambda via AWS_LAMBDA_FUNCTION_NAME, point disk storage at /tmp/uploads there, and wrap the mkdir in try/catch so module load never blows up — request-time errors surface in the right place.