### PR TITLE
fix(frontend): proxy /api/* to Lambda via Vercel rewrite

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -3,6 +3,10 @@
   "outputDirectory": "dist",
   "framework": "vite",
   "rewrites": [
+    {
+      "source": "/api/:path*",
+      "destination": "https://qvst740q80.execute-api.ap-south-1.amazonaws.com/api/:path*"
+    },
     { "source": "/(.*)", "destination": "/index.html" }
   ],
   "headers": [


### PR DESCRIPTION
Same-origin /api/* calls now route through Vercel to the Lambda HTTP API. Eliminates the same-origin 405 we were hitting because VITE_API_URL wasn't baking into the build, drops the CORS preflight (browser thinks it's same-origin), and keeps the cookie domain stable.

If the Lambda URL ever changes (different region or recreated stack), update the destination in this file.