### PR TITLE
fix(routing): send /api/messages/* to EC2 so realtime push works

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -4,6 +4,10 @@
   "framework": "vite",
   "rewrites": [
     {
+      "source": "/api/messages/:path*",
+      "destination": "https://socket.engage-sphere.in/api/messages/:path*"
+    },
+    {
       "source": "/api/:path*",
       "destination": "https://qvst740q80.execute-api.ap-south-1.amazonaws.com/api/:path*"
     },


### PR DESCRIPTION
Lambda has a no-op `io` stub, so any controller that does `io.to(receiverSocketId).emit("newMessage", ...)` from a Lambda invocation silently drops the event — the message persists but the recipient doesn't get a live push until they refresh.

Route all chat-related REST (`/api/messages/*`) to the EC2 socket host where the same Express app runs with a real `io` instance attached. Everything else (`/api/auth`, `/api/users`, `/api/admin`, ...) stays on Lambda.

Cookie still works across both because Vercel rewrites preserve the browser-visible origin (`engage-sphere.in`), so the JWT cookie sticks to the same origin and is sent to whichever rewrite handles the path. JWT_SECRET is identical on Lambda and EC2 (both pull from engagesphere-be / prd in Doppler), so the same token verifies on either backend.