### PR TITLE
fix: stop the markMultipleAsRead loop hammering /api/messages/read/mu…

### DIFF
--- a/frontend/src/components/messages/Messages.jsx
+++ b/frontend/src/components/messages/Messages.jsx
@@ -16,6 +16,7 @@ const Messages = ({ isSelectionMode = false, selectedMessages = new Set(), onMes
 	const { authUser } = useAuthContext();
 	const { selectedConversation } = useConversation();
 	const { markMultipleAsRead } = useMarkMessageAsRead();
+	const updateMultipleMessageStatuses = useConversation((s) => s.updateMultipleMessageStatuses);
 	useListenMessages();
 
 	const messagesArray = Array.isArray(messages) ? messages : [];
@@ -27,6 +28,10 @@ const Messages = ({ isSelectionMode = false, selectedMessages = new Set(), onMes
 	const { scrollToBottomAfterImagesLoad, smoothScrollToBottom, cleanup } = useScrollToBottom();
 
 	// ── Mark visible messages as read ─────────────────────────────
+	// The server only emits the read receipt to the message *sender* (so they
+	// see the blue ticks), not back to the reader. So we must locally mark
+	// these as "read" right after the PUT — otherwise the next render's
+	// filter would still see them as unread and we'd loop on the endpoint.
 	useEffect(() => {
 		if (!authUser || !selectedConversation || loading) return;
 
@@ -37,7 +42,12 @@ const Messages = ({ isSelectionMode = false, selectedMessages = new Set(), onMes
 
 		const t = setTimeout(async () => {
 			const ids = unread.map((m) => m._id);
-			await markMultipleAsRead(ids);
+			const ok = await markMultipleAsRead(ids);
+			if (!ok) return;
+
+			// Local update so the filter above stops finding them.
+			updateMultipleMessageStatuses(ids, "read", new Date().toISOString());
+
 			window.dispatchEvent(
 				new CustomEvent("messagesRead", {
 					detail: {
@@ -49,7 +59,7 @@ const Messages = ({ isSelectionMode = false, selectedMessages = new Set(), onMes
 			);
 		}, 500);
 		return () => clearTimeout(t);
-	}, [authUser, selectedConversation, loading, messagesArray, markMultipleAsRead]);
+	}, [authUser, selectedConversation, loading, messagesArray, markMultipleAsRead, updateMultipleMessageStatuses]);
 
 	// ── Reset unread count when conversation is opened ────────────
 	useEffect(() => {

--- a/frontend/src/hooks/useMarkMessageAsRead.js
+++ b/frontend/src/hooks/useMarkMessageAsRead.js
@@ -1,68 +1,67 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import { useAuthContext } from "../context/AuthContext";
 
 const useMarkMessageAsRead = () => {
 	const [loading, setLoading] = useState(false);
 	const { authUser } = useAuthContext();
 
-	const markAsRead = async (messageId) => {
-		if (!authUser) return false;
-		
-		setLoading(true);
-		try {
-			const res = await fetch(`/api/messages/${messageId}/read`, {
-				method: "PUT",
-				headers: {
-					"Content-Type": "application/json",
-				},
-				credentials: "include",
-			});
-
-			const data = await res.json();
-			if (data.error) {
-				console.error("Error marking message as read:", data.error);
+	// useCallback so the function identity stays stable across renders.
+	// Otherwise consumers that put it in a useEffect dep array re-run their
+	// effect on every render of this hook (the `loading` state churns).
+	const markAsRead = useCallback(
+		async (messageId) => {
+			if (!authUser) return false;
+			setLoading(true);
+			try {
+				const res = await fetch(`/api/messages/${messageId}/read`, {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					credentials: "include",
+				});
+				const data = await res.json();
+				if (data.error) {
+					console.error("Error marking message as read:", data.error);
+					return false;
+				}
+				return true;
+			} catch (error) {
+				console.error("Error marking message as read:", error);
 				return false;
+			} finally {
+				setLoading(false);
 			}
+		},
+		[authUser],
+	);
 
-			return true;
-		} catch (error) {
-			console.error("Error marking message as read:", error);
-			return false;
-		} finally {
-			setLoading(false);
-		}
-	};
-
-	const markMultipleAsRead = async (messageIds) => {
-		if (!authUser || !messageIds || messageIds.length === 0) return false;
-		
-		setLoading(true);
-		try {
-			const res = await fetch(`/api/messages/read/multiple`, {
-				method: "PUT",
-				headers: {
-					"Content-Type": "application/json",
-				},
-				credentials: "include",
-				body: JSON.stringify({ messageIds }),
-			});
-
-			const data = await res.json();
-			if (data.error) {
-				console.error("Error marking messages as read:", data.error);
+	const markMultipleAsRead = useCallback(
+		async (messageIds) => {
+			if (!authUser || !messageIds || messageIds.length === 0) return false;
+			setLoading(true);
+			try {
+				const res = await fetch(`/api/messages/read/multiple`, {
+					method: "PUT",
+					headers: { "Content-Type": "application/json" },
+					credentials: "include",
+					body: JSON.stringify({ messageIds }),
+				});
+				const data = await res.json();
+				if (data.error) {
+					console.error("Error marking messages as read:", data.error);
+					return false;
+				}
+				return true;
+			} catch (error) {
+				console.error("Error marking messages as read:", error);
 				return false;
+			} finally {
+				setLoading(false);
 			}
-
-			return true;
-		} catch (error) {
-			console.error("Error marking messages as read:", error);
-			return false;
-		} finally {
-			setLoading(false);
-		}
-	};
+		},
+		[authUser],
+	);
 
 	return { markAsRead, markMultipleAsRead, loading };
 };
 
-export default useMarkMessageAsRead; 
+export default useMarkMessageAsRead;


### PR DESCRIPTION
…ltiple

Two compounding causes:

1. The server emits the "messagesRead" socket event only to the *sender* (so they see blue ticks). The reader, who is the one calling the PUT, never receives that event, so their local message statuses never flipped to "read" — `messagesArray.filter(m.status !== "read")` kept finding the same set of unread messages on every render and the useEffect re-fired the request. Fix: locally call `updateMultipleMessageStatuses(ids, "read", ...)` right after the PUT succeeds, so the filter is empty next time around.

2. `markMultipleAsRead` was a fresh function reference on every render of useMarkMessageAsRead (the internal `loading` state churned the hook). With it in the useEffect deps array, the effect re-ran on every render, retriggering the timer. Wrapped both `markAsRead` and `markMultipleAsRead` in useCallback([authUser]) for stable identity.