### PR TITLE
fix: clear loading unconditionally in useGetMessages so StrictMode de…

### DIFF
--- a/frontend/src/hooks/useGetMessages.js
+++ b/frontend/src/hooks/useGetMessages.js
@@ -48,12 +48,20 @@ const useGetMessages = () => {
 				setMessages(list);
 				setHasMoreMessages(more);
 			} catch (err) {
+				if (cancelled) return;
 				console.error("Error fetching messages:", err);
 				toast.error(err.message || "Failed to load messages");
 				setMessages([]);
 				setHasMoreMessages(false);
 			} finally {
-				if (!cancelled) setLoading(false);
+				// Always clear loading. In React StrictMode dev, the effect
+				// runs → cleanup → runs again. If we gate this on `!cancelled`,
+				// the first run's fetch resolves *after* cleanup set
+				// cancelled=true, so loading would stay true forever (the
+				// second run takes the fetchedForRef early-exit and doesn't
+				// touch loading). Clearing unconditionally is safe because
+				// `setMessages`/`setHasMoreMessages` are gated by `!cancelled`.
+				setLoading(false);
 			}
 		})();
 


### PR DESCRIPTION
…v doesn't stick

In React StrictMode (dev), the effect runs → cleanup → runs again. Sequence:
  1. Effect run #1: setLoading(true), fetch starts.
  2. Cleanup: sets cancelled=true (closure of run #1).
  3. Effect run #2: takes the fetchedForRef early-exit (same partnerId) and does nothing — including not setLoading(true) again.
  4. Run #1's fetch resolves. cancelled is true, so the finally's `if (!cancelled) setLoading(false)` skipped. Loading stays true forever.

Production builds don't double-invoke, so this only manifested on localhost — chat box stuck on the loading skeleton even though the GET /api/messages/<id> request returned 200.

Fix: clear loading unconditionally in `finally`. The cancelled guard on `setMessages`/`setHasMoreMessages` is enough to prevent a stale fetch from overwriting fresh state.